### PR TITLE
Remove default stale_ttl on cache_setting

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -358,7 +358,6 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Max 'Time To Live' for stale (unreachable) objects.",
-							Default:     300,
 						},
 						"ttl": {
 							Type:        schema.TypeInt,

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -221,7 +221,6 @@ The `cache_setting` block supports:
 on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions).
 * `cache_condition` - (Optional) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
-Default `300`.
 * `ttl` - (Optional) The Time-To-Live (TTL) for the object.
 
 The `gzip` block supports:


### PR DESCRIPTION
- Fastly does not currently have a default