### PR TITLE
Fix cache_setting action documentation

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -217,7 +217,7 @@ conditions execute. Lower numbers execute first.
 The `cache_setting` block supports:
 
 * `name` - (Required) Unique name for this Cache Setting.
-* `action` - (Required) One of `cache`, `pass`, or `restart`, as defined
+* `action` - (Optional) One of `cache`, `pass`, or `restart`, as defined
 on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions).
 * `cache_condition` - (Optional) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.


### PR DESCRIPTION
- action is optional, docs seem to be out of date or incorrect
  - it is optional in Fastly
  - code itself has it set to optional